### PR TITLE
fix: 기본팀은 항상 첫 순서 & 팀 생성시 order는 maxOrder+1

### DIFF
--- a/src/main/java/com/example/Veco/domain/team/exception/code/TeamErrorCode.java
+++ b/src/main/java/com/example/Veco/domain/team/exception/code/TeamErrorCode.java
@@ -11,7 +11,8 @@ public enum TeamErrorCode implements BaseErrorStatus {
     _NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM404_0", "해당 팀을 찾을 수 없습니다."),
     _TEAM_NOT_IN_WORKSPACE(HttpStatus.NOT_FOUND, "TEAM404_1", "팀이 해당 워크스페이스에 없습니다."),
     _TEAM_COUNT_MISMATCH(HttpStatus.BAD_REQUEST, "TEAM404_2", "요청한 팀 개수와 워크스페이스의 팀 개수가 일치하지 않습니다."),
-    _DUPLICATE_TEAM_NAME(HttpStatus.BAD_REQUEST, "TEAM404_3", "중복된 팀 이름입니다.")
+    _DUPLICATE_TEAM_NAME(HttpStatus.BAD_REQUEST, "TEAM404_3", "중복된 팀 이름입니다."),
+    _DEFAULT_TEAM_MUST_BE_FIRST(HttpStatus.BAD_REQUEST, "TEAM404_4", "기본팀은 항상 첫번째 순서입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/Veco/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/example/Veco/domain/team/repository/TeamRepository.java
@@ -5,6 +5,8 @@ import com.example.Veco.domain.workspace.entity.WorkSpace;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -20,4 +22,10 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     boolean existsByName(String name);
 
     boolean existsByNameAndWorkSpace(String name, WorkSpace workSpace);
+
+    @Query("select min(t.id) from Team t where t.workSpace = :workspace")
+    Long findMinTeamIdByWorkSpace(@Param("workspace") WorkSpace workspace);
+
+    @Query("select max(t.order) from Team t where t.workSpace = :workspace")
+    Optional<Integer> findMaxOrderByWorkSpace(@Param("workspace") WorkSpace workSpace);
 }

--- a/src/main/java/com/example/Veco/domain/workspace/converter/WorkspaceConverter.java
+++ b/src/main/java/com/example/Veco/domain/workspace/converter/WorkspaceConverter.java
@@ -115,7 +115,8 @@ public class WorkspaceConverter {
     /**
      * 워크스페이스 내 멤버 + 소속 팀 리스트 응답 DTO 변환
      */
-    public static WorkspaceResponseDTO.WorkspaceMemberWithTeamsDto toWorkspaceMemberWithTeamsDto(
+    public static WorkspaceResponseDTO.WorkspaceMemberWithTeamsDto
+    toWorkspaceMemberWithTeamsDto(
             Member member,
             List<Team> teams,
             LocalDateTime joinedAt


### PR DESCRIPTION
## 👋 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closes #이슈
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. 테스트 혹은 기능에 대한 사진이 첨부되면 좋습니다!-->
<img width="567" height="135" alt="스크린샷 2025-08-13 오후 1 00 55" src="https://github.com/user-attachments/assets/74c757d3-d523-4439-a1a1-9746e08d69a5" />
팀 순서 변경시에도 기본팀은 항상 첫번째 순서.
팀 생성시 order는 팀에서 부여받은 마지막 order + 1로 설정해 팀 순서 맨 마지막에 위치

## 📋 PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📣 To Reviewers
<!-- 이번 수정 관련 전달사항이나 의논할 점이 있다면, 전달할 사람을 @{github id}로 멘션하고 작성해주세요! -->
<!-- 특이사항이 없다면 비워두셔도 좋습니다. -->
