### PR TITLE
✨ [Feat] 회원 탈퇴 api 구현

### DIFF
--- a/src/main/java/com/example/Veco/domain/assignee/repository/AssigneeQueryDsl.java
+++ b/src/main/java/com/example/Veco/domain/assignee/repository/AssigneeQueryDsl.java
@@ -12,5 +12,6 @@ public interface AssigneeQueryDsl {
     List<Assignee> findByGoalIdIn(List<Long> goalIds);
     List<Assignee> findByExternalIdIn(List<Long> externalIds);
     void deleteAllByTypeAndTargetIds(Category type, List<Long> targetIds);
+    List<Assignee> findByTypeAndTargetId(Category type, Long targetId);
 }
 

--- a/src/main/java/com/example/Veco/domain/assignee/repository/AssigneeQueryDslImpl.java
+++ b/src/main/java/com/example/Veco/domain/assignee/repository/AssigneeQueryDslImpl.java
@@ -89,4 +89,19 @@ public class AssigneeQueryDslImpl implements AssigneeQueryDsl {
                 )
                 .execute();
     }
+
+    @Override
+    public List<Assignee> findByTypeAndTargetId(Category type, Long issueId) {
+        QAssignee assignee = QAssignee.assignee;
+        QMember member = QMember.member;
+
+        return queryFactory.selectFrom(assignee)
+                .innerJoin(member).on(member.id.eq(assignee.memberTeam.member.id))
+                .where(
+                        assignee.type.eq(type),
+                        assignee.targetId.eq(issueId),
+                        member.deletedAt.isNull()
+                )
+                .fetch();
+    }
 }

--- a/src/main/java/com/example/Veco/domain/comment/repository/CommentQueryDsl.java
+++ b/src/main/java/com/example/Veco/domain/comment/repository/CommentQueryDsl.java
@@ -1,0 +1,10 @@
+package com.example.Veco.domain.comment.repository;
+
+import com.example.Veco.domain.comment.entity.Comment;
+import com.example.Veco.domain.comment.entity.CommentRoom;
+
+import java.util.List;
+
+public interface CommentQueryDsl {
+    List<Comment> findByCommentRoomOrderByIdDesc(CommentRoom commentRoom);
+}

--- a/src/main/java/com/example/Veco/domain/comment/repository/CommentQueryDslImpl.java
+++ b/src/main/java/com/example/Veco/domain/comment/repository/CommentQueryDslImpl.java
@@ -1,0 +1,32 @@
+package com.example.Veco.domain.comment.repository;
+
+import com.example.Veco.domain.comment.entity.Comment;
+import com.example.Veco.domain.comment.entity.CommentRoom;
+import com.example.Veco.domain.comment.entity.QComment;
+import com.example.Veco.domain.comment.entity.QCommentRoom;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class CommentQueryDslImpl implements CommentQueryDsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Comment> findByCommentRoomOrderByIdDesc(CommentRoom commentRoom) {
+        QComment comment = QComment.comment;
+
+        return queryFactory
+                .selectFrom(comment)
+                .where(comment.commentRoom.eq(commentRoom)
+                        .and(comment.member.deletedAt.isNull()))
+                .orderBy(comment.id.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/example/Veco/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/Veco/domain/comment/repository/CommentRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentQueryDsl {
     List<Comment> findAllByCommentRoomOrderByIdDesc(CommentRoom commentRoom);
     List<Comment> findAllByCommentRoomOrderByIdAsc(CommentRoom commentRoom);
 }

--- a/src/main/java/com/example/Veco/domain/issue/repository/CustomIssueRepositoryImpl.java
+++ b/src/main/java/com/example/Veco/domain/issue/repository/CustomIssueRepositoryImpl.java
@@ -140,7 +140,9 @@ public class CustomIssueRepositoryImpl implements CustomIssueRepository {
                 .select(assignee.memberTeam.member.name)
                 .from(issue)
                 .leftJoin(assignee).on(assignee.type.eq(Category.ISSUE)
-                        .and(assignee.targetId.eq(issue.id)))
+                        .and(assignee.targetId.eq(issue.id))
+                        .and(assignee.memberTeam.member.deletedAt.isNull())
+                )
                 .where(issue.goal.team.id.eq(teamId))
                 .fetch();
     }
@@ -206,8 +208,9 @@ public class CustomIssueRepositoryImpl implements CustomIssueRepository {
         Map<Long, List<Assignee>> result = queryFactory
                 .from(issue)
                 .leftJoin(assignee).on(assignee.type.eq(Category.ISSUE)
-                        .and(assignee.targetId.eq(issue.id)))
-                .leftJoin(member).on(member.id.eq(assignee.memberTeam.member.id))
+                        .and(assignee.targetId.eq(issue.id))
+                        .and(assignee.memberTeam.member.deletedAt.isNull())
+                )
                 .transform(
                         GroupBy.groupBy(issue.id).as(
                                 GroupBy.list(assignee)

--- a/src/main/java/com/example/Veco/domain/issue/service/IssueQueryService.java
+++ b/src/main/java/com/example/Veco/domain/issue/service/IssueQueryService.java
@@ -385,7 +385,7 @@ public class IssueQueryService {
         // 데이터들이 없는 경우
         if (filterResult.stream().allMatch(
                 value -> value.dataCnt().equals(0))
-        ){
+        ) {
             return null;
         }
 
@@ -406,7 +406,6 @@ public class IssueQueryService {
                 .collect(Collectors.toList());
 
 
-
         return IssueConverter.toPageable(resultWithManagers, hasNext, nextCursor, pageSize);
     }
 
@@ -415,8 +414,7 @@ public class IssueQueryService {
                 new IssueException(IssueErrorCode.NOT_FOUND));
 
         // 담당자 조회: 없으면 []
-        List<Assignee> assignees = assigneeRepository.findAllByTypeAndTargetId(Category.ISSUE, issueId)
-                .orElse(new ArrayList<>());
+        List<Assignee> assignees = assigneeRepository.findByTypeAndTargetId(Category.ISSUE, issueId);
 
         // 목표 조회
         Goal goal = null;
@@ -436,7 +434,10 @@ public class IssueQueryService {
         }
 
         CommentRoom commentRooms = commentRoomRepository.findByRoomTypeAndTargetId(Category.ISSUE, issueId);
-        List<Comment> comments = commentRepository.findAllByCommentRoomOrderByIdDesc(commentRooms);
+        List<Comment> comments = null;
+        if (commentRooms != null) {
+            comments = commentRepository.findByCommentRoomOrderByIdDesc(commentRooms);
+        }
 
         return IssueConverter.toDetailIssue(
                 issue,

--- a/src/main/java/com/example/Veco/domain/member/entity/Member.java
+++ b/src/main/java/com/example/Veco/domain/member/entity/Member.java
@@ -10,6 +10,8 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "member")
 @Getter
@@ -54,9 +56,13 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "profile_id", nullable = true)
     private Profile profile;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     // update
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
     public void updateWorkspace(WorkSpace workSpace) { this.workSpace = workSpace; }
+    public void softDelete(){ deletedAt = LocalDateTime.now(); }
 }

--- a/src/main/java/com/example/Veco/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/Veco/domain/member/service/MemberCommandService.java
@@ -1,6 +1,7 @@
 package com.example.Veco.domain.member.service;
 
 import com.example.Veco.domain.member.entity.Member;
+import com.example.Veco.global.auth.user.userdetails.CustomUserDetails;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberCommandService {
@@ -12,4 +13,8 @@ public interface MemberCommandService {
     Member updateProfileImage(MultipartFile file, Member member);
 
     Member deleteProfileImage(Member member);
+
+    Member softDeleteMember(Member member);
+
+    Member withdrawMember(CustomUserDetails customUserDetails);
 }

--- a/src/main/java/com/example/Veco/domain/workspace/error/SettingHandler.java
+++ b/src/main/java/com/example/Veco/domain/workspace/error/SettingHandler.java
@@ -1,0 +1,10 @@
+package com.example.Veco.domain.workspace.error;
+
+import com.example.Veco.global.apiPayload.code.BaseErrorStatus;
+import com.example.Veco.global.apiPayload.exception.VecoException;
+
+public class SettingHandler extends VecoException {
+    public SettingHandler(BaseErrorStatus errorStatus) {
+        super(errorStatus);
+    }
+}

--- a/src/main/java/com/example/Veco/domain/workspace/error/SettingSuccessCode.java
+++ b/src/main/java/com/example/Veco/domain/workspace/error/SettingSuccessCode.java
@@ -1,0 +1,28 @@
+package com.example.Veco.domain.workspace.error;
+
+import com.example.Veco.global.apiPayload.code.BaseSuccessStatus;
+import com.example.Veco.global.apiPayload.dto.SuccessReasonDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum SettingSuccessCode implements BaseSuccessStatus {
+    DELETE(HttpStatus.OK,
+            "SETTING200_1",
+            "성공적으로 삭제했습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public SuccessReasonDTO getReasonHttpStatus() {
+        return SuccessReasonDTO.builder()
+                .isSuccess(true)
+                .httpStatus(status)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/example/Veco/global/auth/oauth2/exception/code/OAuth2ErrorCode.java
+++ b/src/main/java/com/example/Veco/global/auth/oauth2/exception/code/OAuth2ErrorCode.java
@@ -13,6 +13,11 @@ public enum OAuth2ErrorCode implements BaseErrorStatus {
             HttpStatus.BAD_REQUEST,
             "OAUTH2401_0",
             "state 값이 유효하지 않습니다."
+    ),
+    _SOCIAL_UNLINK_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "MEMBER500_1",
+            "소셜 계정 연동 해제에 실패했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/Veco/global/auth/oauth2/service/OAuth2UserService.java
+++ b/src/main/java/com/example/Veco/global/auth/oauth2/service/OAuth2UserService.java
@@ -7,17 +7,30 @@ import com.example.Veco.domain.profile.entity.Profile;
 import com.example.Veco.domain.profile.repository.ProfileRepository;
 import com.example.Veco.global.auth.oauth2.CustomOAuth2User;
 import com.example.Veco.global.auth.oauth2.dto.OAuth2Attribute;
+import com.example.Veco.global.auth.oauth2.exception.OAuth2Exeception;
+import com.example.Veco.global.auth.oauth2.exception.code.OAuth2ErrorCode;
 import com.example.Veco.global.auth.oauth2.userinfo.OAuth2UserInfo;
 import com.example.Veco.global.auth.oauth2.util.OAuth2Util;
+import com.example.Veco.global.auth.user.userdetails.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.Collections;
 import java.util.Map;
@@ -30,7 +43,10 @@ import java.util.Optional;
 public class OAuth2UserService extends DefaultOAuth2UserService {
     private final MemberRepository memberRepository;
     private final ProfileRepository profileRepository;
+    private final OAuth2AuthorizedClientService clientService;
 
+    @Value("${spring.security.oauth2.client.provider.kakao.admin-key}")
+    private String adminKey;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -81,5 +97,50 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
 
         return new CustomOAuth2User(Collections.singleton(new SimpleGrantedAuthority("user")),
                 attributes, oAuth2Attribute.getNameAttributeKey(), member);
+    }
+
+    public void unlinkGoogleAccess(CustomUserDetails customUserDetails) {
+
+        OAuth2AuthorizedClient authorizedClient = clientService.loadAuthorizedClient(
+                "google",
+                customUserDetails.getUsername()
+        );
+
+        if (authorizedClient != null) {
+            String accessToken = authorizedClient.getAccessToken().getTokenValue();
+
+            try {
+                String revokeUrl = "https://oauth2.googleapis.com/revoke?token=" + accessToken;
+
+                WebClient.create()
+                        .post()
+                        .uri(revokeUrl)
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .retrieve()
+                        .bodyToMono(String.class)
+                        .block();
+
+            } catch (Exception e) {
+                log.error("구글 연동 해제 실패", e);
+                throw new OAuth2Exeception(OAuth2ErrorCode._SOCIAL_UNLINK_FAILED);
+            }
+        }
+    }
+
+    public void unlinkKakaoAccount(Long kakaoId) {
+        try {
+            String response = WebClient.create("https://kapi.kakao.com")
+                    .post()
+                    .uri("/v1/user/unlink")
+                    .header(HttpHeaders.AUTHORIZATION, "KakaoAK " + adminKey)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .bodyValue("target_id_type=user_id&target_id=" + kakaoId)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+        } catch (Exception e) {
+            log.error("카카오 연동 해제 실패", e);
+            throw new OAuth2Exeception(OAuth2ErrorCode._SOCIAL_UNLINK_FAILED);
+        }
     }
 }


### PR DESCRIPTION
## 👋 개요
- closes #121 
- 회원 탈퇴 api를 구현했습니다. 소프트 딜리트 방식으로 구현하기 위해 deleted_at 컬럼을 추가했습니다.
- 요청 시 OAuth2 제공자에 대한 연동을 해제하고 DB의 deleted_at에 현재 시각을 저장합니다.
- 이에 따라 모든 이슈 조회, 이슈 상세 조회와 이슈에서 보여지는 댓글 조회 시 탈퇴한 사용자가 조회되지 않도록 변경했습니다.

## 📋 PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📣 To Reviewers
