### PR TITLE
🐛 [Fix] 탈퇴한 회원이 동일 소셜 계정으로 재가입할 때의 문제 수정

### DIFF
--- a/src/main/java/com/example/Veco/domain/assignee/repository/AssigneeQueryDslImpl.java
+++ b/src/main/java/com/example/Veco/domain/assignee/repository/AssigneeQueryDslImpl.java
@@ -91,7 +91,7 @@ public class AssigneeQueryDslImpl implements AssigneeQueryDsl {
     }
 
     @Override
-    public List<Assignee> findByTypeAndTargetId(Category type, Long issueId) {
+    public List<Assignee> findByTypeAndTargetId(Category type, Long targetId) {
         QAssignee assignee = QAssignee.assignee;
         QMember member = QMember.member;
 
@@ -99,7 +99,7 @@ public class AssigneeQueryDslImpl implements AssigneeQueryDsl {
                 .innerJoin(member).on(member.id.eq(assignee.memberTeam.member.id))
                 .where(
                         assignee.type.eq(type),
-                        assignee.targetId.eq(issueId),
+                        assignee.targetId.eq(targetId),
                         member.deletedAt.isNull()
                 )
                 .fetch();

--- a/src/main/java/com/example/Veco/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/Veco/domain/comment/entity/Comment.java
@@ -1,10 +1,14 @@
 package com.example.Veco.domain.comment.entity;
 
 import com.example.Veco.domain.common.BaseEntity;
+import com.example.Veco.domain.mapping.entity.CommentMember;
 import com.example.Veco.domain.member.entity.Member;
 
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -26,6 +30,9 @@ public class Comment extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_room_id")
     private CommentRoom commentRoom;
+
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<CommentMember> commentMembers = new ArrayList<>();
 
     public void setMember(Member member) {
         this.member = member;

--- a/src/main/java/com/example/Veco/domain/comment/repository/CommentQueryDslImpl.java
+++ b/src/main/java/com/example/Veco/domain/comment/repository/CommentQueryDslImpl.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collections;
 import java.util.List;
 
 @Repository
@@ -22,10 +23,13 @@ public class CommentQueryDslImpl implements CommentQueryDsl {
     public List<Comment> findByCommentRoomOrderByIdDesc(CommentRoom commentRoom) {
         QComment comment = QComment.comment;
 
+        if (commentRoom == null) {
+            return Collections.emptyList();
+        }
+
         return queryFactory
                 .selectFrom(comment)
-                .where(comment.commentRoom.eq(commentRoom)
-                        .and(comment.member.deletedAt.isNull()))
+                .where(comment.commentRoom.eq(commentRoom))
                 .orderBy(comment.id.desc())
                 .fetch();
     }

--- a/src/main/java/com/example/Veco/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/Veco/domain/comment/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package com.example.Veco.domain.comment.repository;
 
 import com.example.Veco.domain.comment.entity.Comment;
 import com.example.Veco.domain.comment.entity.CommentRoom;
+import com.example.Veco.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,4 +10,5 @@ import java.util.List;
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentQueryDsl {
     List<Comment> findAllByCommentRoomOrderByIdDesc(CommentRoom commentRoom);
     List<Comment> findAllByCommentRoomOrderByIdAsc(CommentRoom commentRoom);
+    void deleteAllByMember(Member member);
 }

--- a/src/main/java/com/example/Veco/domain/issue/repository/CustomIssueRepositoryImpl.java
+++ b/src/main/java/com/example/Veco/domain/issue/repository/CustomIssueRepositoryImpl.java
@@ -141,9 +141,8 @@ public class CustomIssueRepositoryImpl implements CustomIssueRepository {
                 .from(issue)
                 .leftJoin(assignee).on(assignee.type.eq(Category.ISSUE)
                         .and(assignee.targetId.eq(issue.id))
-                        .and(assignee.memberTeam.member.deletedAt.isNull())
                 )
-                .where(issue.goal.team.id.eq(teamId))
+                .where(issue.team.id.eq(teamId))
                 .fetch();
     }
 
@@ -209,7 +208,6 @@ public class CustomIssueRepositoryImpl implements CustomIssueRepository {
                 .from(issue)
                 .leftJoin(assignee).on(assignee.type.eq(Category.ISSUE)
                         .and(assignee.targetId.eq(issue.id))
-                        .and(assignee.memberTeam.member.deletedAt.isNull())
                 )
                 .transform(
                         GroupBy.groupBy(issue.id).as(

--- a/src/main/java/com/example/Veco/domain/issue/service/IssueQueryService.java
+++ b/src/main/java/com/example/Veco/domain/issue/service/IssueQueryService.java
@@ -434,10 +434,7 @@ public class IssueQueryService {
         }
 
         CommentRoom commentRooms = commentRoomRepository.findByRoomTypeAndTargetId(Category.ISSUE, issueId);
-        List<Comment> comments = null;
-        if (commentRooms != null) {
-            comments = commentRepository.findByCommentRoomOrderByIdDesc(commentRooms);
-        }
+        List<Comment> comments = commentRepository.findByCommentRoomOrderByIdDesc(commentRooms);
 
         return IssueConverter.toDetailIssue(
                 issue,

--- a/src/main/java/com/example/Veco/domain/mapping/entity/MemberTeam.java
+++ b/src/main/java/com/example/Veco/domain/mapping/entity/MemberTeam.java
@@ -2,12 +2,16 @@ package com.example.Veco.domain.mapping.entity;
 
 
 
+import com.example.Veco.domain.assignee.entity.Assignee;
 import com.example.Veco.domain.common.BaseEntity;
 import com.example.Veco.domain.member.entity.Member;
 import com.example.Veco.domain.team.entity.Team;
 import com.example.Veco.global.enums.Role;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -33,4 +37,7 @@ public class MemberTeam extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "team_id")
     private Team team;
+
+    @OneToMany(mappedBy = "memberTeam", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Assignee> assignees = new ArrayList<>();
 }

--- a/src/main/java/com/example/Veco/domain/mapping/repository/MemberTeamRepository.java
+++ b/src/main/java/com/example/Veco/domain/mapping/repository/MemberTeamRepository.java
@@ -35,4 +35,6 @@ public interface MemberTeamRepository extends JpaRepository<MemberTeam, Long> {
     List<MemberTeam> findAllByMemberIdAndTeamIn(Long memberId, Collection<Team> teams);
 
     List<Long> member(Member member);
+
+    void deleteAllByMember(Member member);
 }

--- a/src/main/java/com/example/Veco/domain/member/entity/Member.java
+++ b/src/main/java/com/example/Veco/domain/member/entity/Member.java
@@ -59,10 +59,17 @@ public class Member extends BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+
+
     // update
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
     public void updateWorkspace(WorkSpace workSpace) { this.workSpace = workSpace; }
-    public void softDelete(){ deletedAt = LocalDateTime.now(); }
+    public void softDelete(){
+        deletedAt = LocalDateTime.now();
+        socialUid = null;
+        workSpace = null;
+        email = "";
+    }
 }

--- a/src/main/java/com/example/Veco/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/Veco/domain/member/service/MemberCommandServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.Veco.domain.member.service;
 
+import com.example.Veco.domain.comment.repository.CommentRepository;
+import com.example.Veco.domain.mapping.repository.MemberTeamRepository;
 import com.example.Veco.domain.member.entity.Member;
 import com.example.Veco.domain.member.enums.Provider;
 import com.example.Veco.domain.member.error.MemberErrorStatus;
@@ -34,6 +36,8 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final S3Util s3Util;
     private final OAuth2AuthorizedClientService clientService;
     private final OAuth2UserService oAuth2UserService;
+    private final MemberTeamRepository memberTeamRepository;
+    private final CommentRepository commentRepository;
 
 
     @Transactional
@@ -92,12 +96,14 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     @Transactional
     @Override
     public Member softDeleteMember(Member member) {
+        memberTeamRepository.deleteAllByMember(member);
+        commentRepository.deleteAllByMember(member);
         member.softDelete();
-
         return memberRepository.save(member);
     }
 
     @Override
+    @Transactional
     public Member withdrawMember(CustomUserDetails customUserDetails) {
 
         Member member = memberRepository.findBySocialUid(customUserDetails.getSocialUid())


### PR DESCRIPTION
## 👋 개요
- closes #127 
- 탈퇴한 회원이 동일 소셜 계정으로 재가입했을 때, 기존의 데이터에 접근 가능했던 문제를 수정했습니다. 
- 기존에는 member의 deleted_at을 통해 조회 시 데이터를 필터링하도록 했었는데, 이런 방식으로는 멤버에 접근이 필요한 모든 조회 api의 수정이 불가피할 것 같아 관련 테이블(MemberTeam, Comment 및 하위 테이블인 CommentMember, Assignee) 의 레코드를 hard delete하는 방식을 도입했습니다.
- 또한 탈퇴 시 deleted_at을 설정하는 것과 더불어 socialUid, workspace, email을 초기화하도록 수정했습니다.


## 📋 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📣 To Reviewers
- 조회 관련 api를 간단히 테스트해보았을 때는 문제가 없긴 했는데, 레코드 삭제로 문제가 생기는 부분이 생겼다면 알려주시면 감사하겠습니다!
